### PR TITLE
Clean up build flow a bit

### DIFF
--- a/.sandstorm/build.sh
+++ b/.sandstorm/build.sh
@@ -21,15 +21,13 @@ if [ -f /opt/app/composer.json ] ; then
 fi
 php ../composer.phar self-update
 
-## install npm, bower & gulp
-wget https://www.npmjs.org/install.sh
-sudo bash ./install.sh
-sudo npm install -g gulp
-sudo npm install -g bower
-sudo npm install
+# Install paperwork's npm dependencies
+npm install
 
-## install bower & gulp
+# Install bower dependencies
 bower install
+
+# Run gulp to build static assets
 gulp
 
 # link storage folder 

--- a/.sandstorm/setup.sh
+++ b/.sandstorm/setup.sh
@@ -1,8 +1,12 @@
 #!/bin/bash
 export DEBIAN_FRONTEND=noninteractive
 apt-get update
-apt-get install -y nginx php5-fpm php5-mysql php5-cli php5-dev php5-gd php5-mcrypt mysql-server nodejs nodejs-legacy git
+apt-get install -y nginx php5-fpm php5-mysql php5-cli php5-dev php5-gd php5-mcrypt mysql-server nodejs nodejs-legacy git npm
+# Install bower and gulp
+npm install -g gulp bower
+# Enable mcrypt for PHP
 php5enmod mcrypt
+# Set up nginx config
 unlink /etc/nginx/sites-enabled/default
 cat > /etc/nginx/sites-available/sandstorm-php <<EOF
 server {
@@ -15,19 +19,20 @@ server {
     server_name example.com;
 
     location / {
-        try_files $uri $uri/ /index.php?$query_string;
+        try_files \$uri \$uri/ /index.php?\$query_string;
     }
 
     location ~ \.php$ {
-        try_files $uri =404;
+        try_files \$uri =404;
         fastcgi_pass unix:/var/run/php5-fpm.sock;
         fastcgi_index index.php;
-        fastcgi_param SCRIPT_FILENAME $document_root$fastcgi_script_name;
+        fastcgi_param SCRIPT_FILENAME \$document_root\$fastcgi_script_name;
         include fastcgi_params;
     }
 }
 EOF
 ln -s /etc/nginx/sites-available/sandstorm-php /etc/nginx/sites-enabled/sandstorm-php
+# Stop services outside the sandbox
 service nginx stop
 service php5-fpm stop
 service mysql stop


### PR DESCRIPTION
Some assorted suggestions:
- There's a Ubuntu package for `npm`, so we can use that.
- The bower and gulp tools probably belong in the "vm setup" script, `setup.sh`, so I moved them there.
- npm and bower packages should remain in `build.sh`, but don't need to be installed as root. 

And a bugfix:
- $var in the nginx conf gets substituted by bash.  We need to escape the $ so that we get the $ in the actual config file

With these changes, I can simply:

``` bash
git clone https://github.com/zarvox/paperwork
cd paperwork
vagrant-spk up
vagrant-spk dev
```

and I have a working Paperwork instance :)
